### PR TITLE
Bugfixes

### DIFF
--- a/etc/ssl/turnkey.cnf
+++ b/etc/ssl/turnkey.cnf
@@ -3,8 +3,6 @@
 # Based on the SSLeay example configuration file.
 #
 
-RANDFILE                = /dev/urandom
-
 [ req ]
 default_bits            = 2048
 default_keyfile         = cert.pem

--- a/turnkey-make-ssl-cert
+++ b/turnkey-make-ssl-cert
@@ -207,7 +207,10 @@ create_temporary_cnf() {
   if [[ $IP == true ]]; then
     for addr in $(hostname -I) '127.0.0.1'; do add_san "$addr"; add_ip "$addr"; done
   fi
-
+  # truncate common name if it's too long for openssl
+  if [[ "${#commonName}" -gt 18 ]]; then
+     commonName="${commonName:0:18}"
+  fi
   sed -i "s#@HostName@#\"$commonName\"#" $TMPFILE
 }
 

--- a/turnkey-make-ssl-cert
+++ b/turnkey-make-ssl-cert
@@ -71,8 +71,8 @@ GEN_DH=false
 DH_ONLY=false
 
 clean_up() { # Perform pre-exit housekeeping
-  rm -f $TMPFILE $TMPOUT
-  return
+    [[ $DEBUG != y ]] || return
+    rm -f $TMPFILE $TMPOUT
 }
 
 info() { echo "INFO [$PROGNAME]: $@"; }


### PR DESCRIPTION
Bugfixes to `turnkey-make-ssl`.

Closes https://github.com/turnkeylinux/tracker/issues/1830